### PR TITLE
Fix pip install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current supported languages:
 The tool is not published to Pypi, you can install it directly from source code.
 
 ```shell
-pip install git+https://github.com/long2ice/mccabe.git
+pip install git+https://github.com/frite/mccabe.git
 ```
 
 ## Usage


### PR DESCRIPTION
The URL in the README seems to have an outdated owner name. This PR updates it.